### PR TITLE
Fix custom units from utterance

### DIFF
--- a/skill/config.py
+++ b/skill/config.py
@@ -15,6 +15,7 @@
 FAHRENHEIT = "fahrenheit"
 CELSIUS = "celsius"
 METRIC = "metric"
+IMPERIAL = "imperial"
 METERS_PER_SECOND = "meters per second"
 MILES_PER_HOUR = "miles per hour"
 
@@ -53,11 +54,15 @@ class WeatherConfig:
     
     @property
     def scale(self) -> str:
-        unit_from_settings = self.settings.get("units")
-        if unit_from_settings is not None and unit_from_settings != "default":
-            return unit_from_settings
+        skill_setting = self.settings.get("units", "default")
+        core_setting = self.core_config["system_unit"]
 
-        return self.core_config["system_unit"]
+        system = skill_setting if skill_setting is not "default" \
+            else core_setting
+        
+        if system not in (METRIC, IMPERIAL):
+            return METRIC
+        return system
     
     def speed_unit(self, scale=None) -> str:
         """Use the core configuration to determine the unit of speed.

--- a/skill/config.py
+++ b/skill/config.py
@@ -50,37 +50,32 @@ class WeatherConfig:
     def state(self):
         """The current value of the state name in the device configuration."""
         return self.core_config["location"]["city"]["state"]["name"]
-
+    
     @property
-    def speed_unit(self) -> str:
+    def scale(self) -> str:
+        unit_from_settings = self.settings.get("units")
+        if unit_from_settings is not None and unit_from_settings != "default":
+            return unit_from_settings
+
+        return self.core_config["system_unit"]
+    
+    def speed_unit(self, scale=None) -> str:
         """Use the core configuration to determine the unit of speed.
 
         Returns: (str) 'meters_sec' or 'mph'
         """
-        system_unit = self.core_config["system_unit"]
-        if system_unit == METRIC:
-            speed_unit = METERS_PER_SECOND
+        scale = scale or self.scale
+        if self.scale == METRIC:
+            return METERS_PER_SECOND
         else:
-            speed_unit = MILES_PER_HOUR
+            return MILES_PER_HOUR
 
-        return speed_unit
-
-    @property
-    def temperature_unit(self) -> str:
+    def temperature_unit(self, scale=None) -> str:
         """Use the core configuration to determine the unit of temperature.
 
-        Returns: "celsius" or "fahrenheit"
-        """
-        unit_from_settings = self.settings.get("units")
-        measurement_system = self.core_config["system_unit"]
-        if measurement_system == METRIC:
-            temperature_unit = CELSIUS
+        Returns: "celsius" or "fahrenheit"""
+        scale = scale or self.scale
+        if scale == METRIC:
+            return CELSIUS
         else:
-            temperature_unit = FAHRENHEIT
-        if unit_from_settings is not None and unit_from_settings != "default":
-            if unit_from_settings.lower() == FAHRENHEIT:
-                temperature_unit = FAHRENHEIT
-            elif unit_from_settings.lower() == CELSIUS:
-                temperature_unit = CELSIUS
-
-        return temperature_unit
+            return FAHRENHEIT

--- a/skill/config.py
+++ b/skill/config.py
@@ -65,7 +65,7 @@ class WeatherConfig:
         Returns: (str) 'meters_sec' or 'mph'
         """
         scale = scale or self.scale
-        if self.scale == METRIC:
+        if scale == METRIC:
             return METERS_PER_SECOND
         else:
             return MILES_PER_HOUR

--- a/skill/dialog.py
+++ b/skill/dialog.py
@@ -62,6 +62,7 @@ class WeatherDialog:
         self.config = config
         self.name = None
         self.data = None
+        self.temperature_unit = config.temperature_unit(intent_data.scale)
 
     def _add_location(self):
         """Add location information to the dialog."""
@@ -99,10 +100,11 @@ class CurrentDialog(WeatherDialog):
     def build_weather_dialog(self):
         """Build the components necessary to speak current weather."""
         self.name += "-weather"
+        custom_scale = self.intent_data.scale
         self.data = dict(
             condition=self.weather.condition.description,
             temperature=self.weather.temperature,
-            temperature_unit=self.config.temperature_unit,
+            temperature_unit=self.temperature_unit,
         )
         self._add_location()
 
@@ -129,7 +131,7 @@ class CurrentDialog(WeatherDialog):
         else:
             self.data = dict(temperature=self.weather.temperature)
         self.data.update(
-            temperature_unit=self.intent_data.unit or self.config.temperature_unit
+            temperature_unit=self.temperature_unit
         )
         self._add_location()
 
@@ -219,7 +221,7 @@ class HourlyDialog(WeatherDialog):
         self.data = dict(
             temperature=self.weather.temperature,
             time=get_time_period(self.weather.date_time),
-            temperature_unit=self.intent_data.unit or self.config.temperature_unit,
+            temperature_unit=self.temperature_unit,
         )
         self._add_location()
 
@@ -307,7 +309,7 @@ class DailyDialog(WeatherDialog):
             self.data = dict(temperature=self.weather.temperature.day)
         self.data.update(
             day=get_speakable_day_of_week(self.weather.date_time),
-            temperature_unit=self.intent_data.unit or self.config.temperature_unit,
+            temperature_unit=self.temperature_unit,
         )
         self._add_location()
 

--- a/skill/dialog.py
+++ b/skill/dialog.py
@@ -100,7 +100,6 @@ class CurrentDialog(WeatherDialog):
     def build_weather_dialog(self):
         """Build the components necessary to speak current weather."""
         self.name += "-weather"
-        custom_scale = self.intent_data.scale
         self.data = dict(
             condition=self.weather.condition.description,
             temperature=self.weather.temperature,

--- a/skill/intent.py
+++ b/skill/intent.py
@@ -38,7 +38,7 @@ class WeatherIntent:
         self.utterance = message.data["utterance"]
         self.location = message.data.get("location")
         self.language = language
-        self.unit = message.data.get("unit")
+        self.scale = None
         self.timeframe = CURRENT
 
     @property


### PR DESCRIPTION
Problem: ATM it is not possible to change the temperature unit per utterance.

This introduces a new property/attribute `scale` both to `WeatherConfig` and `WeatherIntent` from which the units (temperature/wind) is derived and fixes a bug where the spoken unit would be sent as a api request param
```10.89.0.6 - - [04/Apr/2023 11:25:36] "GET /v1/owm/onecall?exclude=minutely&lang=de&lat=49.5875&lon=8.35778&units=fahrenheit HTTP/1.1" 200 -```   # has to metric/imperial

Furthermore weather reports can now also be requested in a different unit. 

This is in line with what i intent to add later on, namely pass `SkillRessources` to the dialog class to be able to translate there.

this closes #31 and replaces #8 