### PR TITLE
fix auto weather cache reset

### DIFF
--- a/skill/api.py
+++ b/skill/api.py
@@ -205,7 +205,7 @@ class OpenWeatherMapApi(Api):
             threading.Timer(900, self.clear_cache).start()
 
     def clear_cache(self):
-        os.remove(self.cache_response_location.path)
+        self.cache_response_location.clear()
 
     def set_language_parameter(self, language_config: str):
         """


### PR DESCRIPTION
Problem: the weather cache file is removed from the filesystem. In [certain cases](https://github.com/OpenVoiceOS/skill-ovos-weather/issues/29) this leads to exceptions.

Since the cache is a `JsonStorage` object it is better to call `clear` flushing the content.

Closes: #29 