### PR TITLE
Fix Spanish translations

### DIFF
--- a/locale/es-es/dialog/current/current-condition-expected-local.dialog
+++ b/locale/es-es/dialog/current/current-condition-expected-local.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-Sí, va a ser {condition} hoy
+Sí, va a haber {condition} hoy
 Parece que hoy habrá {condition}

--- a/locale/es-es/dialog/current/current-condition-expected-location.dialog
+++ b/locale/es-es/dialog/current/current-condition-expected-location.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-Sí, va a ser {condition} en {location}
+Sí, va a haber {condition} en {location}
 En {location}, parece que hoy habrá {condition}

--- a/locale/es-es/dialog/current/current-condition-not-expected-location.dialog
+++ b/locale/es-es/dialog/current/current-condition-not-expected-location.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-No, en {location} {condition} se espera hoy
+No, en {location} se espera hoy {condition}
 No, el pronóstico dice {condition} hoy en {location}

--- a/locale/es-es/dialog/current/current-sunrise-future-location.dialog
+++ b/locale/es-es/dialog/current/current-sunrise-future-location.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-el amanecer fue en {time} hoy en {location}
+el amanecer fue a las {time} hoy en {location}
 el sol salió a las {time} hoy en {location}

--- a/locale/es-es/dialog/current/current-sunrise-past-local.dialog
+++ b/locale/es-es/dialog/current/current-sunrise-past-local.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-la salida del sol fue en {time} hoy
+la salida del sol fue a las {time} hoy
 hoy ha salido el sol a las {time}

--- a/locale/es-es/dialog/current/current-sunrise-past-location.dialog
+++ b/locale/es-es/dialog/current/current-sunrise-past-location.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-el amanecer fue en {time} hoy en {location}
+el amanecer fue a las {time} hoy en {location}
 el sol salió a las {time} hoy en {location}

--- a/locale/es-es/dialog/current/current-sunset-future-local.dialog
+++ b/locale/es-es/dialog/current/current-sunset-future-local.dialog
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
 hoy el sol se pondrá a las {time}
-la puesta de sol será a {time} hoy
+la puesta de sol será a las {time} hoy
 el sol se pondrá a las {time} de hoy

--- a/locale/es-es/dialog/current/current-sunset-future-location.dialog
+++ b/locale/es-es/dialog/current/current-sunset-future-location.dialog
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
-la puesta de sol será en {time} hoy en {location}
+la puesta de sol será a las {time} hoy en {location}
 el sol se pondrá a las {time} hoy en {location}
 en {location} el sol se pondrá hoy a las {time}

--- a/locale/es-es/dialog/current/current-sunset-past-local.dialog
+++ b/locale/es-es/dialog/current/current-sunset-past-local.dialog
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
-la puesta de sol estaba en {time} hoy
+la puesta de sol era a las {time} hoy
 hoy el sol se ha puesto a las {time}
-el sol se puso a {time} hoy
+el sol se puso a las {time} hoy

--- a/locale/es-es/dialog/current/current-sunset-past-location.dialog
+++ b/locale/es-es/dialog/current/current-sunset-past-location.dialog
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
-puesta de sol fue en {time} hoy en {location}
-en {location} el sol se puso a {time} hoy
+puesta de sol fue a las {time} hoy en {location}
+en {location} el sol se puso a las {time} hoy
 el sol se puso a las {time} hoy en {location}

--- a/locale/es-es/dialog/current/current-temperature-local.dialog
+++ b/locale/es-es/dialog/current/current-temperature-local.dialog
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
-Actualmente es {temperature} grados {temperature_unit}.
-Actualmente hace 0 grados.
-Ahora mismo, está a 0 grados.
+Actualmente hay {temperature} grados {temperature_unit}.
+Actualmente hay {temperature} grados.
+Ahora mismo, hay {temperature} grados.

--- a/locale/es-es/dialog/current/current-temperature-location.dialog
+++ b/locale/es-es/dialog/current/current-temperature-location.dialog
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
-Actualmente es {temperature} grados {temperature_unit} en {location}.
-Actualmente hace {temperature} grados en {location}.
-Ahora mismo, hace {temperature} grados en {location}.
+Actualmente hay {temperature} grados {temperature_unit} en {location}.
+Actualmente hay {temperature} grados en {location}.
+Ahora mismo, hay {temperature} grados en {location}.

--- a/locale/es-es/dialog/current/current-weather-local.dialog
+++ b/locale/es-es/dialog/current/current-weather-local.dialog
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
-Actualmente es {condition} y {temperature} grados {temperature_unit}.
+Actualmente hay {condition} y {temperature} grados {temperature_unit}.
 Actualmente hay {condition} y {temperature} grados.
 Ahora mismo, hay {condition} y {temperature} grados.

--- a/locale/es-es/dialog/current/current-weather-location.dialog
+++ b/locale/es-es/dialog/current/current-weather-location.dialog
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
 Ahora mismo, hay {condition} y {temperature} grados en {location}.
-Actualmente es {condition} y {temperature} grados {temperature_unit} en {location}.
+Actualmente hay {condition} y {temperature} grados {temperature_unit} en {location}.
 {location} tiene {condition} y actualmente está a {temperature} grados.

--- a/locale/es-es/dialog/daily/daily-condition-expected-local.dialog
+++ b/locale/es-es/dialog/daily/daily-condition-expected-local.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-Sí, espera {condition} {day}
+Sí, se espera que haya {condition} {day}
 Sí, la previsión es de {condition} {day}

--- a/locale/es-es/dialog/daily/daily-condition-expected-location.dialog
+++ b/locale/es-es/dialog/daily/daily-condition-expected-location.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
 Sí, la previsión es {condition} en {location} {day}
-Sí, espera {condition} en {location} {day}
+Sí, se espera que haya {condition} en {location} {day}

--- a/locale/es-es/dialog/daily/daily-condition-not-expected-local.dialog
+++ b/locale/es-es/dialog/daily/daily-condition-not-expected-local.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-No, {condition} se espera {day}
+No, se espera {condition} {day}
 No, {day} la previsión es de {condition}

--- a/locale/es-es/dialog/daily/daily-condition-not-expected-location.dialog
+++ b/locale/es-es/dialog/daily/daily-condition-not-expected-location.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
 No, {day} la previsión es de {condition} en {location}
-No, en {location} {condition} se espera {day}
+No, en {location} se espera {condition} {day}

--- a/locale/es-es/dialog/daily/daily-sunrise-local.dialog
+++ b/locale/es-es/dialog/daily/daily-sunrise-local.dialog
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
-{day} el sol saldrá a {time}
+{day} el sol saldrá a las {time}
 el sol saldrá a las {time} {day}
-la salida del sol será en {time} {day}
+la salida del sol será a las {time} {day}

--- a/locale/es-es/dialog/daily/daily-sunrise-location.dialog
+++ b/locale/es-es/dialog/daily/daily-sunrise-location.dialog
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
-en {location} el amanecer será en {time} {day}
-{day} el sol saldrá a {time} en {location}
+en {location} el amanecer será a las {time} {day}
+{day} el sol saldrá a las {time} en {location}
 el sol saldrá a las {time} {day} en {location}

--- a/locale/es-es/dialog/daily/daily-sunset-local.dialog
+++ b/locale/es-es/dialog/daily/daily-sunset-local.dialog
@@ -1,5 +1,4 @@
 # auto translated from en-us to es-es
-{day} el sol se pondrá a {time}
-la puesta de sol será en {time} {day}
-el sol se pondrá a {time} {day}
+{day} el sol se pondrá a las {time}
+la puesta de sol será a las {time} {day}
 el sol se pondrá a las {time} {day}

--- a/locale/es-es/dialog/daily/daily-sunset-location.dialog
+++ b/locale/es-es/dialog/daily/daily-sunset-location.dialog
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
-el sol se pondrá en {time} {day} en {location}
-{day} el sol se pondrá a {time} en {location}
-en {location} la puesta de sol será en {time} {day}
+el sol se pondrá a las {time} {day} en {location}
+{day} el sol se pondrá a las {time} en {location}
+en {location} la puesta de sol será a las {time} {day}

--- a/locale/es-es/dialog/daily/daily-temperature-high-location.dialog
+++ b/locale/es-es/dialog/daily/daily-temperature-high-location.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
 {location} tendrá una máxima de {temperature} grados {day}
-Será tan alto como {temperature} grados en {location} {day}
+Será tan alta como {temperature} grados en {location} {day}

--- a/locale/es-es/dialog/daily/daily-temperature-local.dialog
+++ b/locale/es-es/dialog/daily/daily-temperature-local.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-{day} será {temperature}
+{day} habrá {temperature}
 {day} la temperatura será de {temperature} grados.

--- a/locale/es-es/dialog/daily/daily-temperature-location.dialog
+++ b/locale/es-es/dialog/daily/daily-temperature-location.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-{day} será {temperature} grados en {location}
+{day} habrá {temperature} grados en {location}
 {day}, {location} tendrá una temperatura de {temperature} grados

--- a/locale/es-es/dialog/daily/daily-weather-local.dialog
+++ b/locale/es-es/dialog/daily/daily-weather-local.dialog
@@ -1,6 +1,6 @@
 # auto translated from en-us to es-es
-{day} espera {condition}, con un máximo de {high_temperature} y un mínimo de {low_temperature}
-{day} será {condition} con un máximo de {high_temperature} y un mínimo de {low_temperature}
+{day} se espera {condition}, con un máximo de {high_temperature} y un mínimo de {low_temperature}
+{day} habrá {condition} con un máximo de {high_temperature} y un mínimo de {low_temperature}
 Esperar {condition}, con un máximo de {high_temperature} y un mínimo de {low_temperature} {day}
 {day} el máximo será {high_temperature} y el mínimo {low_temperature}, con {condition}
 La previsión {day} es {condition} con un máximo de {high_temperature} y un mínimo de {low_temperature}

--- a/locale/es-es/dialog/error/no-forecast.dialog
+++ b/locale/es-es/dialog/error/no-forecast.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-No tengo un pronóstico {day}
-Lo siento, no conozco el pronóstico {day}
+No tengo un pronóstico para {day}
+Lo siento, no conozco el pronóstico para {day}

--- a/locale/es-es/dialog/hourly/hourly-condition-expected-local.dialog
+++ b/locale/es-es/dialog/hourly/hourly-condition-expected-local.dialog
@@ -1,2 +1,2 @@
 # auto translated from en-us to es-es
-Sí, la previsión {time} para predice {condition}
+Sí, la previsión para {time} predice {condition}

--- a/locale/es-es/dialog/hourly/hourly-condition-expected-location.dialog
+++ b/locale/es-es/dialog/hourly/hourly-condition-expected-location.dialog
@@ -1,2 +1,2 @@
 # auto translated from en-us to es-es
-Sí, va a ser {condition} este {time}
+Sí, va a haber {condition} este {time}

--- a/locale/es-es/dialog/hourly/hourly-precipitation-next-local.dialog
+++ b/locale/es-es/dialog/hourly/hourly-precipitation-next-local.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-La previsión es de una probabilidad {percent} de {precipitation} a {time}
-Hay una probabilidad {percent} de {precipitation} en {time}
+La previsión es de una probabilidad {percent} de {precipitation} a las {time}
+Hay una probabilidad {percent} de {precipitation} a las {time}

--- a/locale/es-es/dialog/hourly/hourly-precipitation-next-location.dialog
+++ b/locale/es-es/dialog/hourly/hourly-precipitation-next-location.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-En {location} hay {percent} posibilidad de {precipitation} en {time}
-La previsión es de una probabilidad de {percent} en {location} en {time}
+En {location} hay {percent} posibilidad de {precipitation} a las {time}
+La previsión es de una probabilidad de {percent} en {location} a las {time}

--- a/locale/es-es/dialog/hourly/hourly-temperature-local.dialog
+++ b/locale/es-es/dialog/hourly/hourly-temperature-local.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-En el {time}, será {temperature} grados
-Será de unos {temperature} grados en el {time}
+A las {time}, habrá {temperature} grados
+Habrá unos {temperature} grados a las {time}

--- a/locale/es-es/dialog/hourly/hourly-temperature-location.dialog
+++ b/locale/es-es/dialog/hourly/hourly-temperature-location.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-En el {time}, será {temperature} grados en {location}
-En {location} será de unos {temperature} grados en el {time}
+A las {time}, habrá {temperature} grados en {location}
+En {location} habrá unos {temperature} grados a las {time}

--- a/locale/es-es/dialog/hourly/hourly-weather-local.dialog
+++ b/locale/es-es/dialog/hourly/hourly-weather-local.dialog
@@ -1,5 +1,5 @@
 # auto translated from en-us to es-es
-Más tarde será {condition} y alrededor de {temperature} grados
-Será {condition}, con temperaturas cercanas a {temperature}
-Más tarde será {condition} y {temperature} grados
+Más tarde habrá {condition} y alrededor de {temperature} grados
+Habrá {condition}, con temperaturas cercanas a {temperature}
+Más tarde habrá {condition} y {temperature} grados
 Alrededor de {temperature} grados con {condition}

--- a/locale/es-es/dialog/hourly/hourly-weather-location.dialog
+++ b/locale/es-es/dialog/hourly/hourly-weather-location.dialog
@@ -1,5 +1,5 @@
 # auto translated from en-us to es-es
-{location} tiempo en las próximas horas será {condition} y {temperature} grados
+En {location} el tiempo en las próximas horas será {condition} y {temperature} grados
 {location} estará alrededor de {temperature} con {condition}
 {location} será de aproximadamente {temperature} grados con {condition}
-Más tarde será {condition} en {location}, con temperaturas alrededor de {temperature}
+Más tarde habrá {condition} en {location}, con temperaturas alrededor de {temperature}

--- a/locale/es-es/dialog/weekly/weekly-condition.dialog
+++ b/locale/es-es/dialog/weekly/weekly-condition.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-En {days} esperar {condition}
+En {days} se espera {condition}
 La previsión es de {condition} en {days}

--- a/locale/es-es/regex/location.rx
+++ b/locale/es-es/regex/location.rx
@@ -1,1 +1,1 @@
-.*\b(at|in) (?P<Location>(?!\bcelsius\b|\bfahrenheit\b) *.+)
+.*\b(en) (?P<Location>(?!\bcelsius\b|\bfahrenheit\b) *.+)

--- a/locale/es-es/vocabulary/condition/clear.voc
+++ b/locale/es-es/vocabulary/condition/clear.voc
@@ -1,5 +1,4 @@
 # auto translated from en-us to es-es
 soleado
 sol
-borrar
 buen tiempo

--- a/locale/es-es/vocabulary/condition/clouds.voc
+++ b/locale/es-es/vocabulary/condition/clouds.voc
@@ -1,6 +1,5 @@
 # auto translated from en-us to es-es
 nublado
 nubes dispersas
-nube
 nubes
 pocas nubes

--- a/locale/es-es/vocabulary/condition/thunderstorm.voc
+++ b/locale/es-es/vocabulary/condition/thunderstorm.voc
@@ -1,4 +1,3 @@
 # auto translated from en-us to es-es
 tormenta
-asaltando
 tormentoso

--- a/locale/es-es/vocabulary/date-time/couple.voc
+++ b/locale/es-es/vocabulary/date-time/couple.voc
@@ -1,2 +1,2 @@
 # auto translated from en-us to es-es
-pareja
+par

--- a/locale/es-es/vocabulary/date-time/later.voc
+++ b/locale/es-es/vocabulary/date-time/later.voc
@@ -1,6 +1,8 @@
 # auto translated from en-us to es-es
-próximas horas
 próxima hora
+próximas horas
 pocas horas
+próximas pocas horas
 un par de horas
+siguiente par de horas
 más tarde

--- a/locale/es-es/vocabulary/date-time/next.voc
+++ b/locale/es-es/vocabulary/date-time/next.voc
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-de nuevo
 siguiente
+de nuevo

--- a/locale/es-es/vocabulary/date-time/now.voc
+++ b/locale/es-es/vocabulary/date-time/now.voc
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-ahora
 actual
+ahora

--- a/locale/es-es/vocabulary/date-time/number-days.voc
+++ b/locale/es-es/vocabulary/date-time/number-days.voc
@@ -1,25 +1,23 @@
 # auto translated from en-us to es-es
+de 2 días
+de dos días
 próximos 2 días
-6 días
-seis días
-seis días s
-próximos días
-cuatro días
-5 días
-3 días
-próximos cuatro días
-4 días
-cuatro días s
-próximos tres días
-próximos 5 días
-2 días
-cinco días
-próximos 6 días
+próximo par de días
+próximo par de días
+de 3 días
+de tres días
 próximos 3 días
-próximos seis días
+próximos tres días
+próximos días
+de 4 días
+de cuatro días
 próximos 4 días
+próximos cuatro días
+de 5 días
+de cinco días
+próximos 5 días
 próximos cinco días
-tres días
-6 días s
-dos días
-próximos dos días
+de 6 dias
+de seis días
+próximos 6 días
+proximos seis días

--- a/locale/es-es/vocabulary/date-time/relative-day.voc
+++ b/locale/es-es/vocabulary/date-time/relative-day.voc
@@ -1,19 +1,20 @@
 # auto translated from en-us to es-es
-el jueves
+mañana
+de mañana
 ayer
+de ayer
+lunes
+el lunes
+martes
+el martes
+miércoles
+el miércoles
+jueves
+el jueves
+viernes
+el viernes
+sábado
 el sábado
 domingo
-el martes
-el miércoles
-de ayer
-miércoles
-el lunes
-el viernes
-mañana
-lunes
-sábado
-martes
-días
 el domingo
-viernes
-jueves
+días

--- a/locale/es-es/vocabulary/date-time/relative-time.voc
+++ b/locale/es-es/vocabulary/date-time/relative-time.voc
@@ -1,6 +1,7 @@
 # auto translated from en-us to es-es
-noche
 mañana
+por la tarde
+por la tarde noche
+noche
 esta noche
 durante la noche
-por la tarde

--- a/locale/es-es/vocabulary/date-time/today.voc
+++ b/locale/es-es/vocabulary/date-time/today.voc
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-de hoy
 hoy
+de hoy

--- a/locale/es-es/vocabulary/temperature/cold.voc
+++ b/locale/es-es/vocabulary/temperature/cold.voc
@@ -1,4 +1,4 @@
 # auto translated from en-us to es-es
 congelación
 frío
-genial
+fresco

--- a/locale/es-es/vocabulary/temperature/low.voc
+++ b/locale/es-es/vocabulary/temperature/low.voc
@@ -1,5 +1,5 @@
 # auto translated from en-us to es-es
-más bajo
 bajo
-mínimo
+más bajo
 min
+mínimo


### PR DESCRIPTION
I kept the order in `date-time` folder. I guess it matters?

I also changed the sentences for using words instead of adjectives, as I saw in `dialog/condition`. However, they will sound weird if using adjectives (which can be found in `vocabulary/condition`)