### PR TITLE
test: add en-US end2end intent-routing suite (ovoscope)

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -12,4 +12,4 @@ jobs:
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
-      test_path: 'test'
+      test_path: 'test/unittests'


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Follow-up to #192 (already merged). Originally added an ovoscope end2end suite so intent routing is regression-tested in CI.

Rebased onto current dev: the end2end suite this PR proposed (`test_intents_en_us.py`, the `ovoscope.yml` job wiring, and the `ovoscope` test dependency) was independently merged to dev via #189 and refined via #205, so those pieces are now redundant and were dropped during the rebase in favor of dev's existing, more thorough version (network mocking, error-branch coverage, adapt + padacioso pipelines).

## Changes remaining after rebase
- `.github/workflows/build-tests.yml` — points the generic build matrix at `test/unittests` only, so the network-adjacent end2end suite runs exclusively through the dedicated `ovoscope` job instead of duplicating it in every Python-version build.
- `test/end2end/__init__.py` — package marker, missing before.

## Local result
`pytest test/unittests` 4 passed; `pytest test/end2end` 121 passed; `pytest test` (full suite) 125 passed.
