### PR TITLE
fix: allow ovos-workshop 9.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "requests>=2.31.0",
     "pytz",
     "ovos-utils>=0.4.0,<1.0.0",
-    "ovos-workshop>=2.2.0,<9.0.0",
+    "ovos-workshop>=2.2.0,<10.0.0",
     "ovos-number-parser>=0.0.1,<1.0.0",
     "ovos-date-parser>=0.0.2,<1.0.0",
     "ovos-utterance-normalizer>=0.0.1,<1.0.0",


### PR DESCRIPTION
ovos-core 2.5.0a2 requires `ovos-workshop>=9.0.2a1`; this repo's `<9.0.0` cap is one of 24 blocking the auto-generated constraints-alpha from resolving latest workshop (caught by raspOVOS's new Tier 2 `pip check` gate, which found shipped images with a broken dep graph). Cap bumped to `<10.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)