### PR TITLE
fix(da-DK): restore {condition} and {day} placeholder names

### DIFF
--- a/locale/da-DK/dialog/current/current-condition-expected-local.dialog
+++ b/locale/da-DK/dialog/current/current-condition-expected-local.dialog
@@ -1,2 +1,2 @@
-Det ser ud til, at der vil være {tilstand} i dag
-Ja, det bliver {condition} i dag
+Det ser ud til, at der vil være {condition} i dag
+Ja, det bliver {condition} i dag

--- a/locale/da-DK/dialog/daily/daily-sunset-local.dialog
+++ b/locale/da-DK/dialog/daily/daily-sunset-local.dialog
@@ -1,4 +1,4 @@
 solen går ned kl. {time} {day}
 solnedgang vil være på {time} {day}
-{dag} går solen ned kl. {time}
+{day} går solen ned kl. {time}
 {day} solen vil gå ned kl. {time}


### PR DESCRIPTION
Found via ovos-localize validation while doing a general da-DK translation review.

- `current-condition-expected-local.dialog`: line 1 had `{tilstand}` instead of `{condition}` (line 2 in the same file already had it right)
- `daily-sunset-local.dialog`: line 3 had `{dag}` instead of `{day}` (lines 1, 2, 4 in the same file already had it right)

Both are internal inconsistencies within the same file - the placeholder must match the English source exactly since the skill substitutes by that key, otherwise that dialog variant either speaks the literal unsubstituted placeholder or fails to render.