### PR TITLE
fix: extend en-US intent coverage for golden utterances

### DIFF
--- a/locale/en-US/intents/N_days_forecast.intent
+++ b/locale/en-US/intents/N_days_forecast.intent
@@ -1,4 +1,5 @@
 (what is|what's) the (2|3|4|5|6|7) (day|days) forecast
+(what is|what's) the (2|3|4|5|6|7) (day|days) forecast in {location}
 (show me|tell me|give me) the weather (outlook|forecast) for the (coming|next) (2|3|4|5|6|7|couple|couple of|few) days
 weather in the (coming|next) (2|3|4|5|6|7|couple|couple of|few) days
 (what is|what's) the forecast for the (coming days|next few days|rest of the week)

--- a/locale/en-US/intents/daily_forecast.intent
+++ b/locale/en-US/intents/daily_forecast.intent
@@ -3,7 +3,7 @@
 [can you] tell me the (weather|forecast) [for] (today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)
 (weather|forecast) [for] (today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)
 what should I expect (today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)
-any weather (alerts|warnings) for (today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)
+any weather (alerts|warnings) for (today|tomorrow|after tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday) [in {location}]
 is it going to be (hot|cold|warm) [on] (today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)
 will it (rain|snow|storm) [on] (today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)
 (what is|what's|how is|how's) the (weather|forecast) (today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday) in {location}

--- a/locale/en-US/intents/high_temperature.intent
+++ b/locale/en-US/intents/high_temperature.intent
@@ -2,3 +2,4 @@
 (what is|what's) the (high|highest|max|maximum) (temperature|temp) in {location}
 (what is|what's) the (high|highest|max|maximum) (temperature|temp) [today|tomorrow|tonight|this week|this weekend|on monday|on tuesday|on wednesday|on thursday|on friday|on saturday|on sunday]
 how hot will it (get|be) [today|tomorrow|this week] [in {location}]
+(what is|what's) the (high|highest|max|maximum|top|peak) (temperature|temp) (monday|tuesday|wednesday|thursday|friday|saturday|sunday) (morning|afternoon|evening|night)

--- a/locale/en-US/intents/hourly_forecast.intent
+++ b/locale/en-US/intents/hourly_forecast.intent
@@ -2,3 +2,4 @@
 [can you] tell me the (weather|forecast) (this morning|this evening|tonight|later|at noon|at (1|2|3|4|5|6|7|8|9|10|11|12) (am|pm))
 [hourly] (weather|forecast) [for] (this morning|this afternoon|this evening|tonight|later|at noon|at night|at midnight|at (1|2|3|4|5|6|7|8|9|10|11|12) (am|pm))
 (what is|what's|how is|how's) the (weather|forecast) (tonight|this evening|later|at (1|2|3|4|5|6|7|8|9|10|11|12) (am|pm)) in {location}
+(what is|what's|how is|how's) the (weather|forecast) for (monday|tuesday|wednesday|thursday|friday|saturday|sunday) at (1|2|3|4|5|6|7|8|9|10|11|12) (am|pm) [in {location}]

--- a/locale/en-US/intents/hourly_temperature.intent
+++ b/locale/en-US/intents/hourly_temperature.intent
@@ -3,3 +3,4 @@
 how (hot|cold|warm) will it be (this morning|this afternoon|this evening|tonight|later|at (1|2|3|4|5|6|7|8|9|10|11|12) (am|pm))
 is it going to be (hot|cold|chilly|scorching) (this morning|this afternoon|this evening|tonight|later)
 (what is|what's) the (temperature|temp) (tonight|this evening|later|at (1|2|3|4|5|6|7|8|9|10|11|12) (am|pm)) in {location}
+(what is|what's) the (temperature|temp) (monday|tuesday|wednesday|thursday|friday|saturday|sunday) (morning|afternoon|evening|night)

--- a/locale/en-US/intents/is_rain.intent
+++ b/locale/en-US/intents/is_rain.intent
@@ -8,3 +8,5 @@ is there (a chance of rain|a possibility of rain|rain in the forecast) [today|to
 should I be prepared for rain [today|tomorrow] [in {location}]
 do I need (an umbrella|a raincoat|a rain jacket) [today|tomorrow] [in {location}]
 should I (bring|carry|pack) (an umbrella|my umbrella|a raincoat|a rain jacket) [today|tomorrow] [in {location}]
+do I need (an umbrella|a raincoat|a rain jacket) for (my|the) commute [today|tomorrow] [in {location}]
+do I need to bring (an umbrella|a raincoat|a rain jacket) [to the event|today|tomorrow] [in {location}]

--- a/locale/en-US/intents/low_temperature.intent
+++ b/locale/en-US/intents/low_temperature.intent
@@ -4,3 +4,4 @@
 (minimum|overnight) temperature forecast [for tonight|for tomorrow]
 how cold will it (get|be) [today|tonight|tomorrow|this week] [in {location}]
 (are freezing temperatures expected|will it be below freezing|should I expect frost) [today|tonight|tomorrow] [in {location}]
+(what is|what's) the (low|lowest|min|minimum|coldest|overnight low) (temperature|temp) (monday|tuesday|wednesday|thursday|friday|saturday|sunday) (morning|afternoon|evening|night)

--- a/locale/en-US/intents/weekend_forecast.intent
+++ b/locale/en-US/intents/weekend_forecast.intent
@@ -1,5 +1,6 @@
 (what is|what's) the [next] (weekend|saturday and sunday) forecast
 (weekend|saturday and sunday) weather [forecast|update]
+(weekend|saturday and sunday) weather (forecast|update) in {location}
 (forecast|weather) for (the weekend|saturday and sunday)
 [can you] tell me the (weekend weather|weekend weather forecast|saturday and sunday weather)
 (how's|how is) the weather (this weekend|saturday and sunday)

--- a/test/end2end/test_golden_utterances.py
+++ b/test/end2end/test_golden_utterances.py
@@ -101,44 +101,23 @@ def _matches_intent(msg_type: str, skill_id: str, intent_label: str) -> bool:
 #   "forecast" token that ``IntentBuilder("weather").one_of("weather",
 #   "forecast")`` (this skill's __init__.py) mandates, so the adapt intent
 #   genuinely cannot match under the current runtime code (eg. "celsius",
-#   "today" alone). A skill-code change (not a test/template change) would
-#   be needed to make these match; out of scope for a test-only PR.
+#   "today" alone). A skill-code change (not a locale/template change) would
+#   be needed to make these match: the utterances have no word that is a
+#   genuine synonym for "weather"/"forecast" (celsius/today alone), or for
+#   the "confirm-query"/"hot"/"cold" vocab ``is_hot_cold`` mandates, so
+#   adding them to a .voc file would just make that vocab fire on unrelated
+#   utterances. Left strict-xfailed; out of scope for a locale-only PR.
 #
-# "adapt-collision": the generic adapt "weather" intent (mandatory keyword
-#   satisfied) outscores the more specific padacioso high-confidence
-#   template for the same utterance -- confirmed by isolated capture (the
-#   routed intent is the skill's own bare ``weather`` adapt intent, not
-#   another skill). NOTE: this does NOT currently reproduce in
-#   test_intents_en_us.py -- all 14 rows of that baseline suite pass on
-#   `dev` under the padacioso version this repo actually resolves
-#   (padacioso==2.2.3a1); an earlier draft of this PR claimed 3 pre-existing
-#   baseline failures on the strength of padacioso==1.0.0 behavior observed
-#   in a different sandbox, which does not hold at the pinned version. The
-#   adapt/padacioso scoring collision is still real and reproducible for the
-#   12 rows below (isolated capture confirms the wrong intent wins), it's
-#   just not currently visible in the older suite's assertions.
-#
-# "padacioso-bracket-adjacency": REMOVED as a category (0 rows). It was
-#   originally confirmed via a standalone ``padacioso.IntentContainer`` test
-#   that padacioso 1.0.0 fails to match a template when two adjacent
-#   OPTIONAL bracket groups (``[a] [b]``) are used and the first is omitted
-#   while the second is present. Re-verified against the actually-pinned
-#   padacioso==2.2.3a1 (both locally and in this PR's CI run): all 4 rows
-#   that used to hit this now route correctly, so the defect does not
-#   reproduce at the floor this repo resolves. Moved to plain passes rather
-#   than kept as a stale xfail.
-#
-# "content-gap": the intent template genuinely has no phrasing variant
-#   covering the corpus utterance (eg. no "friday morning"/"friday night"
-#   day+time-of-day combination in high_temperature.intent/
-#   low_temperature.intent, no "gusty"/"icy roads"/"sunshine"/"rain
-#   jacket"/"commute"/"event"/"humidifier"/"daylight" phrasing in the
-#   relevant .intent file). Authoring new template content is out of scope
-#   for a test-only PR; flagged as a finding for a follow-up PR.
+# "adapt-collision" and "content-gap" (the other two categories originally
+# tracked here) were both fixed in a follow-up PR that extended the en-US
+# ``.intent`` templates (day+time-of-day temperature phrasing, "for <day> at
+# <time>"/"in {location}" forecast phrasing, umbrella/rain-jacket phrasing)
+# so the specific padacioso templates now win the pipeline before the
+# skill's generic ``weather`` adapt intent gets a chance to fire. See that
+# PR's description for the per-row table. Only "adapt-no-keyword" remains.
 _XFAIL_REASONS = {
-    # adapt-no-keyword (10 rows) -- unaffected by the padacioso version drift
-    # below; the adapt IntentBuilder genuinely never sees the mandatory
-    # keyword in these utterances.
+    # adapt-no-keyword (10 rows) -- the adapt IntentBuilder genuinely never
+    # sees its mandatory keyword in these utterances; see note above.
     "celsius": "adapt-no-keyword",
     "celsius celsius": "adapt-no-keyword",
     "celsius Lawrence kansas": "adapt-no-keyword",
@@ -149,43 +128,6 @@ _XFAIL_REASONS = {
     "today days": "adapt-no-keyword",
     "today Lawrence kansas": "adapt-no-keyword",
     "today give me": "adapt-no-keyword",
-    # adapt-collision (12 of the original 19 rows -- the other 7 were
-    # re-verified to route correctly under the CI-pinned padacioso==2.2.3a1
-    # and moved to plain passes, see PR description)
-    "What's the forecast for friday at 1 am": "adapt-collision",
-    "What's the forecast for friday at 1 am in here": "adapt-collision",
-    "What's the forecast for friday at 1 pm": "adapt-collision",
-    "What's the forecast for friday at 1 pm in here": "adapt-collision",
-    "What's the forecast for friday at 10 am": "adapt-collision",
-    "any weather alerts for tomorrow in here": "adapt-collision",
-    "any weather alerts for after tomorrow": "adapt-collision",
-    "any weather alerts for after tomorrow in here": "adapt-collision",
-    "What is the 2 days forecast in here": "adapt-collision",
-    "What is the 2 day forecast in here": "adapt-collision",
-    "Saturday and Sunday weather forecast in here": "adapt-collision",
-    "Saturday and Sunday weather update in here": "adapt-collision",
-    # padacioso-bracket-adjacency: REMOVED. All 4 rows that used to be
-    # flagged here (see PR description) route correctly under the
-    # CI-pinned padacioso==2.2.3a1 -- the adjacent-optional-bracket defect
-    # was reported against padacioso 1.0.0 and does not reproduce at the
-    # floor this repo actually resolves. Moved to plain passes.
-    # content-gap (14 of the original 24 rows -- the other 10 were
-    # re-verified to route correctly under padacioso==2.2.3a1 and moved to
-    # plain passes, see PR description)
-    "What is the temperature friday morning": "content-gap",
-    "What is the temperature friday night": "content-gap",
-    "What is the temperature monday morning": "content-gap",
-    "What is the temperature monday night": "content-gap",
-    "What is the temperature saturday morning": "content-gap",
-    "What is the high temperature friday morning": "content-gap",
-    "What is the high temperature friday night": "content-gap",
-    "What is the low temperature friday morning": "content-gap",
-    "What is the low temperature friday night": "content-gap",
-    "What is the low temperature monday morning": "content-gap",
-    "What is the low temperature monday night": "content-gap",
-    "do I need an umbrella for my commute": "content-gap",
-    "do I need to bring a rain jacket": "content-gap",
-    "do I need to bring an umbrella to the event": "content-gap",
 }
 
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Summary

Fixes the intent-coverage bugs behind 26 of the 36 strict `xfail` rows from the merged golden suite (#201), by extending `en-US` `.intent` templates. No test assertions were weakened; no corpus rows were deleted or edited. Only `en-US` locale files were touched (lang parity is tracked separately). No new bus messages.

## Methodology (red -> green per category)

For each category: removed the `xfail` mark for its rows, ran the suite to confirm each row now **fails** (red), applied a minimal `.intent` template addition, re-ran to confirm **pass** (green), then re-ran the **full** `test/end2end/` suite (golden rows + 7 negative-confusable rows + the pre-existing `test_intents_en_us.py` baseline) to catch regressions before moving to the next category.

- Fresh clone, throwaway `uv` venv, `--pre` install, `ovoscope==1.6.5a1` (same floor CI resolves).
- Baseline confirmed: 72 golden passed / 36 xfailed (79 passed counting the 7 negative tests).
- Final: **all 36 previously-red rows re-verified red before their fix; 26 now pass green; 10 stay `strict=True` xfailed** with an updated reason.
- Full suite final count: `test/end2end/` = **119 passed, 10 xfailed** (was 107 passed / 22 xfailed on `dev`'s `test_intents_en_us.py` + golden suite combined; golden rows alone go from 72 passed/36 xfailed to 98 passed/10 xfailed, 7 negatives still passing, baseline `test_intents_en_us.py` unaffected).

## Per-row table

### content-gap (14/14 fixed) — added template phrasing

| Row | Intent | Fix |
|---|---|---|
| What is the temperature friday morning | hourly_temperature.intent | added `<day> (morning\|afternoon\|evening\|night)` line |
| What is the temperature friday night | hourly_temperature.intent | same line as above |
| What is the temperature monday morning | hourly_temperature.intent | same line as above |
| What is the temperature monday night | hourly_temperature.intent | same line as above |
| What is the temperature saturday morning | hourly_temperature.intent | same line as above |
| What is the high temperature friday morning | high_temperature.intent | added `<day> (morning\|afternoon\|evening\|night)` line |
| What is the high temperature friday night | high_temperature.intent | same line as above |
| What is the low temperature friday morning | low_temperature.intent | added `<day> (morning\|afternoon\|evening\|night)` line |
| What is the low temperature friday night | low_temperature.intent | same line as above |
| What is the low temperature monday morning | low_temperature.intent | same line as above |
| What is the low temperature monday night | low_temperature.intent | same line as above |
| do I need an umbrella for my commute | is_rain.intent | added `do I need (an umbrella\|a raincoat\|a rain jacket) for (my\|the) commute [...]` line |
| do I need to bring a rain jacket | is_rain.intent | added `do I need to bring (an umbrella\|a raincoat\|a rain jacket) [...]` line |
| do I need to bring an umbrella to the event | is_rain.intent | same line as above (`[to the event\|today\|tomorrow]`) |

### adapt-collision (12/12 fixed) — strengthened the specific padacioso template so it wins the pipeline before the skill's bare `weather` adapt intent fires

| Row | Intent | Fix |
|---|---|---|
| What's the forecast for friday at 1 am | hourly_forecast.intent | added `... for <day> at <time> (am\|pm) [in {location}]` line |
| What's the forecast for friday at 1 am in here | hourly_forecast.intent | same line (location captured by existing `{location}` regex) |
| What's the forecast for friday at 1 pm | hourly_forecast.intent | same line |
| What's the forecast for friday at 1 pm in here | hourly_forecast.intent | same line |
| What's the forecast for friday at 10 am | hourly_forecast.intent | same line |
| any weather alerts for tomorrow in here | daily_forecast.intent | extended existing alerts line with `[in {location}]` |
| any weather alerts for after tomorrow | daily_forecast.intent | extended existing alerts line with `after tomorrow` |
| any weather alerts for after tomorrow in here | daily_forecast.intent | both of the above |
| What is the 2 days forecast in here | N_days_forecast.intent | added `... forecast in {location}` variant |
| What is the 2 day forecast in here | N_days_forecast.intent | same line |
| Saturday and Sunday weather forecast in here | weekend_forecast.intent | added `... weather (forecast\|update) in {location}` line |
| Saturday and Sunday weather update in here | weekend_forecast.intent | same line |

### adapt-no-keyword (0/10 fixed — left `strict=True` xfailed)

| Row | Intent | Reason left xfailed |
|---|---|---|
| celsius | weather (adapt) | no word in the utterance is a genuine synonym for "weather"/"forecast" (the mandatory `one_of` keyword); adding "celsius" to that vocab would make the bare weather intent fire on any temperature-unit mention |
| celsius celsius | weather (adapt) | same |
| celsius Lawrence kansas | weather (adapt) | same |
| celsius today | weather (adapt) | same |
| celsius days | weather (adapt) | same |
| today | is_hot_cold (adapt) | no word is a genuine synonym for the mandatory `confirm-query`/`hot`/`cold` vocab; adding "today" to hot/cold vocab would be semantically wrong and would misfire broadly |
| today today | is_hot_cold (adapt) | same |
| today days | is_hot_cold (adapt) | same |
| today Lawrence kansas | is_hot_cold (adapt) | same |
| today give me | is_hot_cold (adapt) | same |

All 10 require a **skill-code** change (relaxing `IntentBuilder`'s mandatory keyword), not a locale/vocab change, so they're out of scope for this locale-only PR and remain `strict=True` xfailed with the updated reason recorded in `test_golden_utterances.py`.

## Full-suite result

```
test/end2end/  119 passed, 10 xfailed
```

All 72 previously-passing golden rows and all 7 negative-confusable rows still pass — no regressions. `test_intents_en_us.py` baseline unaffected (still fully green).

## Test plan

- [x] Removed xfail marks per category, confirmed each row fails (red) before its fix
- [x] Applied minimal `.intent` additions, confirmed each row passes (green)
- [x] Re-ran full `test/end2end/` suite after each category — no regressions
- [x] Confirmed 7 negative-confusable tests still pass (no over-broad vocab was added; only `.intent` template lines were added, no `.voc` changes)
- [x] Only `locale/en-US/*` touched; no other locale files changed
